### PR TITLE
exposing bitrates, channels and resolution via docker/env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ A docker image is provided for easy deployment:
 Docker Compose (recommended):
 
 ```yaml
+version: '3'
 services:
   vrchat-jellyfin:
     image: ghcr.io/gurrrrrrett3/vrchat-jellyfin:master
@@ -45,6 +46,11 @@ services:
       JELLYFIN_HOST: <http[s]://URL>
       JELLYFIN_USERNAME: <USERNAME>
       JELLYFIN_PASSWORD: <PASSWORD>
+      AUDIO_BITRATE: 128000
+      VIDEO_BITRATE: 3000000
+      MAX_AUDIO_CHANNELS: 2
+      MAX_HEIGHT: 720
+      MAX_WIDTH: 1280
 ```
 
 Docker CLI:
@@ -57,6 +63,10 @@ docker run -d \
 -e JELLYFIN_HOST=<http[s]://URL> \
 -e JELLYFIN_USERNAME=<USERNAME> \
 -e JELLYFIN_PASSWORD=<PASSWORD> \
+-e AUDIO_BITRATE: 128000 \
+-e VIDEO_BITRATE: 3000000 \
+-e MAX_HEIGHT: 720 \
+-e MAX_WIDTH: 1280 \
 ghcr.io/gurrrrrrett3/vrchat-jellyfin:master
 ```
 

--- a/encodingSettings.js
+++ b/encodingSettings.js
@@ -1,12 +1,14 @@
-module.exports.encodingSettings = {
-	audioBitrate: "128000", // 128kbps
-	videoBitrate: "10000000", // 10mbps
-	maxAudioChannels: "2", // stereo
-	maxHeight: "720", // 720p
-	maxWidth: "1280",
+const encodingSettings = {
+  audioBitrate: process.env.AUDIO_BITRATE || "128000", // 128kbps
+  videoBitrate: process.env.VIDEO_BITRATE || "3000000", // 3mbps
+  maxAudioChannels: process.env.MAX_AUDIO_CHANNELS || "2", // stereo
+  maxHeight: process.env.MAX_HEIGHT || "720", // 720p
+  maxWidth: process.env.MAX_WIDTH || "1280",
 
-	// caution changing these values
-	container: "mp4",
-	videoCodec: "h264",
-	audioCodec: "aac",
+  // caution changing these values
+  container: process.env.CONTAINER || "mp4", // Default container format
+  videoCodec: process.env.VIDEO_CODEC || "h264", // Default video codec
+  audioCodec: process.env.AUDIO_CODEC || "aac", // Default audio codec
 };
+
+module.exports.encodingSettings = encodingSettings;

--- a/encodingSettings.js
+++ b/encodingSettings.js
@@ -6,9 +6,9 @@ const encodingSettings = {
   maxWidth: process.env.MAX_WIDTH || "1280",
 
   // caution changing these values
-  container: process.env.CONTAINER || "mp4", // Default container format
-  videoCodec: process.env.VIDEO_CODEC || "h264", // Default video codec
-  audioCodec: process.env.AUDIO_CODEC || "aac", // Default audio codec
+  container: "mp4", // Default container format
+  videoCodec: "h264", // Default video codec
+  audioCodec: "aac", // Default audio codec
 };
 
 module.exports.encodingSettings = encodingSettings;


### PR DESCRIPTION
I got things working, but for my uses I really needed to be able to mess about with the encoding settings readily - so I made them accessible as env vars from the Docker/compose. Cool?