### PR TITLE
Add Caddy config sample to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,46 @@ pm2 save
 ```
 Make sure to do `pm2 startup` if you haven't already so it autostarts
 
+## Sample Caddy config
+
+Caddy can be used to allow streaming to the web over HTTPS.
+
+```
+media.example.com {
+        # VRChat (AVPro) doesn't like tls1.3
+        tls {
+                # Due to a lack of DHE support, you -must- use an ECDSA cert to support IE 11 on Windows 7
+                ciphers TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+        }
+
+        header Strict-Transport-Security "max-age=63072000"
+        header X-Content-Type-Options nosniff
+
+        header Content-Security-Policy "
+        default-src 'self';
+        style-src 'self';
+        script-src 'self';
+        font-src 'self';
+        img-src data: 'self';
+        form-action 'self';
+        connect-src 'self';
+        frame-ancestors 'none';
+        "
+
+        # Videos don't require sign-in, just the interface
+        @auth {
+                not path /v/*
+        }
+
+        basicauth @auth {
+                vrcuser MY_PASSWORD_HASH # Password can be obtained with `caddy hash-password`
+        }
+
+        reverse_proxy 1.2.3.4:4000 {
+        }
+}
+```
+
 ## Usage
 
 Go to the web interface (default port is 4000), select media, and copy the link. Paste the link into the vrchat client to play the media.


### PR DESCRIPTION
Heya!

First off, neat project! Thanks for making this, very useful for me and some family I have overseas.

I wanted to be able to secure the interface a bit more, since it's by default just exposed on the document root, and always signed in. I ended up using Caddy (which I've been using for other services) to reverse-proxy, using HTTP basic-auth for everything but paths to videos. I had issues with tls1.3, so I used https://ssl-config.mozilla.org/ to get the best viable config for SSL. I believe that should be sufficient to keep it semi-secured?

Let me know if this makes sense, and if there's anything obvious I missed!